### PR TITLE
Feat/add dependencies makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 *.exe
 *.out
 *.app
+webserver
+webtest

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ $(TEST_D)/%.o : $(SRC_D)/%.cpp $(SRC_D)/%.cpp
 
 all: $(NAME)
 
+deps: 
+	@chmod +x install_deps.sh
+	@./install_deps.sh
 clean:
 	@echo -n "Cleaning... "
 	@$(RM) $(OBJ)

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [[ -r /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ "$ID" == "debian" || "$ID" == "ubuntu" || "$ID" == "linuxmint" ]]; then
+        echo "Debian-based OS detected. Installing dependencies..."
+		sudo apt-get -y install googletest
+        exit 0
+    fi
+fi
+
+if [[ -r /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ "$ID" == "arch" || "$ID" == "manjaro" ]]; then
+        echo "Arch-based OS detected. Installing dependencies..."
+		pacman -S gtest
+        exit 0
+    fi
+fi
+
+echo "Unknown OS detected."
+exit 1


### PR DESCRIPTION
## What
- Introduce a new make rule to simplify the installation of project dependencies on a fresh computer.
- Implement an OS verification script that automatically installs the required dependencies based on the detected operating system.

## Why
The purpose of these changes is to enhance the user experience and ensure seamless test execution for anyone accessing this repository. With the new make rule and OS verification script in place, individuals can effortlessly set up the project dependencies without encountering any issues or inconsistencies. This streamlines the onboarding process and facilitates smooth testing procedures for all contributors.

## Future
Add a Dockerfile