### PR TITLE
feat: add makefile rules for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Prerequisites
 *.d
 
+#tests
+*.test
+
 # Compiled Object files
 *.slo
 *.lo
@@ -30,3 +33,4 @@
 *.exe
 *.out
 *.app
+webserver

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ RAW_C		=	main.cpp
 OBJ			=	$(addprefix $(OBJ_D)/,$(RAW_C:.cpp=.o))
 INCLUDES	=	$(addprefix $(INC_D)/,$(RAW_H))
 
-TEST_D		=	test
-TEST_C		=	test.cpp
+TEST_D		=	tests
 TEST_OBJ	=	$(addprefix $(TEST_D)/,$(TEST_C:.cpp=.o))
 
 
@@ -31,19 +30,38 @@ $(NAME): $(OBJ) $(INCLUDES)
 $(OBJ_D)/%.o : $(SRC_D)/%.cpp
 	@echo -n "Compiling $@... "
 	@mkdir -p $(OBJ_D)
-	@$(CC) $(CFLAGS) -c $< -I $(INC_D) -I $(INC) -o $@
+	$(CC) $(CFLAGS) -c $< -I $(INC_D) -I $(INC) -o $@
 	@echo Done!
-	
-test: $(TEST_OBJ) $(INCLUDES)
-	@echo -n "Compiling tests... "
-	@$(CC) $(CFLAGS) $(TFLAGS) $(TEST_OBJ) -o webtest
-	@echo Done!
-	@echo run ./webtest to execute the tests
 
-$(TEST_D)/%.o : $(SRC_D)/%.cpp $(SRC_D)/%.cpp
-	@echo -n "Compiling $@... "
-	@$(CC) $(CFLAGS) -c $< -I $(INC_D) -I $(INC) -o $@
-	@echo Done!
+
+#To execute a testfile just run make test_file FILENAME=filename without the .spec.cpp
+#Our test files must be ended with .spec.cpp
+.PHONY: test_file
+test_file: 
+	@filename="$(FILENAME)"; \
+    filepath=$$(find . -name "$$filename.spec.cpp" -type f -print -quit); \
+    if [ -n "$$filepath" ]; then \
+        make test FILE_PATH=$$filepath FILENAME=$$filename; \
+		./${TEST_D}/${FILENAME}; \
+    else \
+        echo "File not found"; \
+    fi
+
+.PHONY: test_all
+
+test_all:
+	@echo "Running all tests"; \
+    files=$$(find . -name "*.spec.cpp" -type f); \
+    for filepath in $$files; do \
+        filename=$$(basename "$$filepath" .spec.cpp); \
+        make test FILE_PATH="$$filepath" FILENAME="$$filename"; \
+		echo "Running test for $$filepath"; \
+        ./${TEST_D}/$$filename; \
+		echo "Done!"; \
+    done
+
+test:$(INCLUDES)
+	@$(CC) $(CFLAGS) $(FILE_PATH) $(TFLAGS)  -I $(INC_D) -o $(TEST_D)/${FILENAME}.test
 
 all: $(NAME)
 


### PR DESCRIPTION
## What
- Add a makefile rule to execute a test individually
- Add a makefile rule to execute all test files

## Why
The purpose of this pull request is to enhance the development workflow by introducing new makefile rules for test execution. The changes include:

1. **Individual Test Execution**: A new makefile rule is added to enable the execution of a single test file. This provides developers with the ability to run specific tests without needing to execute the entire test suite. It promotes better test granularity and improves the efficiency of debugging and development iterations.

2. **All Tests Execution**: Another makefile rule is introduced to execute all test files collectively. This rule offers a convenient way to run the complete test suite, ensuring comprehensive testing of the codebase. It simplifies the process of running all tests in a single command, streamlining the testing phase of the development workflow.

## How to Use
To use the new makefile rules, follow the instructions below:

- **Individual Test Execution**: Run the following command to execute a specific test file:
  ```bash
  make test_file FILENAME=<test_filename_without_extension>
  ```
  Replace `<test_filename_without_extension>` with the desired test filename. The test file should have the ".spec.cpp" extension.

  Example:
  ```bash
  make test_file FILENAME=parsing
  ```

- **All Tests Execution**: Use the following command to execute all test files:
  ```bash
  make test_all
  ```
  This command will run all the test files in the current directory and its subdirectories. Please ensure that all the test files follow the naming convention of ending with ".spec.cpp".